### PR TITLE
fix for 'Timeout context manager should be used inside a task'

### DIFF
--- a/commands/deescord.py
+++ b/commands/deescord.py
@@ -11,6 +11,7 @@ import giphypop
 G = giphypop.Giphy()
 
 from keys import discord_app
+from discord_invite import invite_link
 from peewee import fn
 from commands.twitch import mod_only
 from commands.models import Quote, Command
@@ -165,20 +166,7 @@ async def twitchwgaff(network, channel, message):
 
 @command('invite')
 async def bot_invite(network, channel, message):
-    perms = [
-        '0x0000400',  # READ_MESSAGES
-        '0x0000800',  # SEND_MESSAGES
-        '0x0002000',  # DELETE_MESSAGES
-        '0x0008000',  # ATTACH_FILES
-        '0x0004000',  # EMBED_LINKS ?
-        '0x0100000',  # CONNECT (to voice)
-        '0x0200000',  # SPEAK
-        '0x2000000',  # DETECT VOICE
-    ]
-
-    perm_int = sum([int(perm, 0) for perm in perms])
-
-    link = 'https://discordapp.com/oauth2/authorize?&client_id={}&scope=bot&permissions={}'.format(discord_app, perm_int)
+    link = invite_link(discord_app)
     await network.send_message(channel, 'Invite me to your server here: {}'.format(link))
 
 

--- a/discord_invite.py
+++ b/discord_invite.py
@@ -1,0 +1,20 @@
+
+# enabled permissions for discord bot
+perms = [
+    '0x0000400',  # READ_MESSAGES
+    '0x0000800',  # SEND_MESSAGES
+    '0x0002000',  # DELETE_MESSAGES
+    '0x0008000',  # ATTACH_FILES
+    '0x0004000',  # EMBED_LINKS ?
+    '0x0100000',  # CONNECT (to voice)
+    '0x0200000',  # SPEAK
+    '0x2000000',  # DETECT VOICE
+]
+
+
+perm_int = sum([int(perm, 0) for perm in perms])
+
+# Given the bot clientid, returns a link for authorizing the bot on your server
+def invite_link(discord_clientid):
+    link = 'https://discordapp.com/oauth2/authorize?&client_id={}&scope=bot&permissions={}'.format(discord_clientid, perm_int)
+    return link

--- a/j4ne.py
+++ b/j4ne.py
@@ -107,6 +107,7 @@ def main():
     define("twitch", default=True, help="Connect to Twitch chat servers")
     define("twitchapi", default=True, help="Connect to Twitch API")
     define("discord", default=True, help="Connect to Discord chat servers")
+    define("newbot", default=False, help="Generates a Discord server invite link for a new bot instance")
 
     define("runtests", default=False, help="Run tests")
 
@@ -148,7 +149,16 @@ def main():
     http_server.listen(options.port)
     info('Serving on port %d' % options.port)
 
-    # connect to discord 
+    # Discord options:
+    ## new bot instance authentication
+    if options.newbot:
+        from keys import discord_app
+        from discord_invite import invite_link
+        print("Please go to the following link to authorize the bot, then press `Enter`:\n")
+        print(invite_link(discord_app))
+        input("\nPress `Enter` to continue...")
+
+    ## connect to discord 
     if options.discord:
         from networks.deescord import Discord
         app.Discord = Discord()

--- a/networks/deescord.py
+++ b/networks/deescord.py
@@ -29,6 +29,8 @@ Dlogger = Dlogger()
 # instantiate this here to use decorators
 client = discord.Client()  # loop defaults to asyncio.get_event_loop()
 
+# We need to wrap connect() as a task to prevent timeout error at runtime.
+# based on the following suggested fix: https://github.com/KeepSafe/aiohttp/issues/1176
 def connect_deco(func):
     async def wrapper(*args, **kwargs):
         return asyncio.get_event_loop().create_task(func(*args, **kwargs))

--- a/networks/deescord.py
+++ b/networks/deescord.py
@@ -29,6 +29,10 @@ Dlogger = Dlogger()
 # instantiate this here to use decorators
 client = discord.Client()  # loop defaults to asyncio.get_event_loop()
 
+def connect_deco(func):
+    async def wrapper(*args, **kwargs):
+        return asyncio.get_event_loop().create_task(func(*args, **kwargs))
+    return wrapper
 
 class Discord(object):
     _Twitter = None
@@ -36,8 +40,8 @@ class Discord(object):
 
     client = client  # so that network specific commands can access lower levels
 
-    @gen.coroutine
-    def connect(self):
+    @connect_deco
+    async def connect(self):
 
         """
         @client.event
@@ -59,9 +63,8 @@ class Discord(object):
             await self.on_message(message)
 
         # this lived in a while True loop for a bit, to handle restarting
-        while True:
-            info('Connecting to Discord..')
-            yield client.start(discord_token)
+        info('Connecting to Discord..')
+        await client.start(discord_token)
 
     async def send_message(self, channel, message):
         return await client.send_message(channel, message)


### PR DESCRIPTION
fixed the timeout error following the suggested fix here:
https://github.com/KeepSafe/aiohttp/issues/1176

also, switched to a "native coroutine"  definition for `connect()` as described here:
http://www.tornadoweb.org/en/stable/guide/coroutines.html?highlight=wait_for#python-3-5-async-and-await